### PR TITLE
Link Boost as a PRIVATE library

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -66,18 +66,22 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_cpp/reindexer.cpp
   src/rosbag2_cpp/reindexers/sequential_reindexer.cpp)
 
-target_link_libraries(${PROJECT_NAME} Boost::filesystem)
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    Boost::filesystem
+)
 
 ament_target_dependencies(${PROJECT_NAME}
-  ament_index_cpp
-  pluginlib
-  rcpputils
-  rcutils
-  rosbag2_storage
-  rosidl_runtime_c
-  rosidl_runtime_cpp
-  rosidl_typesupport_cpp
-  rosidl_typesupport_introspection_cpp
+  PUBLIC
+    ament_index_cpp
+    pluginlib
+    rcpputils
+    rcutils
+    rosbag2_storage
+    rosidl_runtime_c
+    rosidl_runtime_cpp
+    rosidl_typesupport_cpp
+    rosidl_typesupport_introspection_cpp
 )
 
 

--- a/rosbag2_cpp/package.xml
+++ b/rosbag2_cpp/package.xml
@@ -9,7 +9,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libboost-filesystem-dev</build_depend>
+
   <depend>ament_index_cpp</depend>
+  <depend>libboost-filesystem</depend>
   <depend>pluginlib</depend>
   <depend>rcutils</depend>
   <depend>rcpputils</depend>


### PR DESCRIPTION
This adds boost rosdep keys to rosbag2_cpp and also links it as a PRIVATE library, since none of its dependants needs to explicitly link it in.

Signed-off-by: P. J. Reed <preed@swri.org>